### PR TITLE
Create update-upstream-relay-repo.yml

### DIFF
--- a/.github/workflows/update-upstream-relay-repo.yml
+++ b/.github/workflows/update-upstream-relay-repo.yml
@@ -1,0 +1,29 @@
+# https://stackoverflow.com/a/68213855/16672148
+name: Send submodule updates to mozilla/fx-private-relay repo
+
+on:
+  push:
+    branches: 
+      - main
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          repository: mozilla/fx-private-relay
+          token: ${{ secrets.RELAY_REPO_TOKEN }}
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This adds a new GitHub Action to this repo which will automatically update the upstream [mozilla/fx-private-relay](https://github.com/mozilla/fx-private-relay) submodule every time translations are updated. This should keep [the Relay dev server](https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/) updated with all the latest translations so translators can review their translations on that server.