### PR TITLE
New strings for fx-private-relay/pull/1024

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -151,6 +151,7 @@ profile-label-create-domain = Get your email domain
 profile-label-domain = Email Domain:
 profile-label-domain-tooltip = Create your unique and custom email domain.
 profile-label-reset = Reset
+profile-label-apply = Apply
 
 # This string is followed by an email address
 profile-label-forward-emails = Forward emails to:
@@ -178,6 +179,10 @@ profile-stat-label-blocked = Emails Blocked
 profile-stat-label-forwarded = Emails Forwarded
 profile-stat-label-aliases-used = Email aliases used
 profile-filter-search-placeholder = Search aliases
+profile-filter-category-option-active-aliases = Active aliases
+profile-filter-category-option-disabled-aliases = Disabled aliases
+profile-filter-category-option-relay-aliases = Relay aliases
+profile-filter-category-option-domain-based-aliases = Domain-based aliases
 
 ## Banner Messages (displayed on the profile page)
 


### PR DESCRIPTION
Related PR: https://github.com/mozilla/fx-private-relay/pull/1024

These strings are used in the new filter-by-category feature. 

Preview: 

<img width="322" alt="image" src="https://user-images.githubusercontent.com/2692333/130834017-1fa54670-2539-42d9-94b4-382fc2f6b390.png">
