### PR TITLE
Remove duplicated string ID

### DIFF
--- a/de/app.ftl
+++ b/de/app.ftl
@@ -215,11 +215,9 @@ banner-choose-subdomain-submit = Domain erhalten
 banner-pack-upgrade-headline-html = Mit einem Upgrade auf <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> erhalten Sie noch mehr Alias-Adressen.
 banner-pack-upgrade-copy = { -brand-name-firefox } { -brand-name-relay-premium } bietet Ihnen unbegrenzt viele Alias-E-Mail-Adressen und Ihre eigene E-Mail-Domain und schützt Sie so im Internet.
 banner-pack-upgrade-cta = Jetzt Upgrade ausführen
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Sie können beliebige Adressen mit @{ $subdomain } erstellen
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Sie können beliebige Adressen mit @{ $subdomain } erstellen
+banner-choose-subdomain-description = Sie können beliebige Adressen mit @{ $subdomain } erstellen
 
 ## Success Messages
 

--- a/el/app.ftl
+++ b/el/app.ftl
@@ -211,11 +211,9 @@ banner-choose-subdomain-submit = Απόκτηση τομέα
 banner-pack-upgrade-headline-html = Αναβαθμίστε στο <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> για περισσότερα ψευδώνυμα
 banner-pack-upgrade-copy = Με απεριόριστα ψευδώνυμα email και τον δικό σας τομέα email, το { -brand-name-firefox } { -brand-name-relay-premium } σάς προστατεύει στο διαδίκτυο.
 banner-pack-upgrade-cta = Αναβάθμιση τώρα
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Μπορείτε να δημιουργήσετε οποιαδήποτε διεύθυνση @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Μπορείτε να δημιουργήσετε οποιαδήποτε διεύθυνση @{ $subdomain }
+banner-choose-subdomain-description = Μπορείτε να δημιουργήσετε οποιαδήποτε διεύθυνση @{ $subdomain }
 
 ## Success Messages
 

--- a/en-GB/app.ftl
+++ b/en-GB/app.ftl
@@ -215,11 +215,9 @@ banner-choose-subdomain-submit = Get Domain
 banner-pack-upgrade-headline-html = Upgrade to <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> to get more aliases
 banner-pack-upgrade-copy = With unlimited email aliases and your own email domain, { -brand-name-firefox } { -brand-name-relay-premium } helps you stay protected online.
 banner-pack-upgrade-cta = Upgrade Now
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = You can make up any address @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = You can make up any address @{ $subdomain }
+banner-choose-subdomain-description = You can make up any address @{ $subdomain }
 
 ## Success Messages
 

--- a/en/app.ftl
+++ b/en/app.ftl
@@ -223,7 +223,7 @@ banner-choose-subdomain-label = Your domain is:
 
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = You can make up any address @{ $subdomain }
+banner-choose-subdomain-description = You can make up any address @{ $subdomain }
 
 ## Success Messages
 

--- a/fr/app.ftl
+++ b/fr/app.ftl
@@ -186,11 +186,9 @@ banner-choose-subdomain-submit = Obtenir le domaine
 banner-pack-upgrade-headline-html = Passez à <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> pour obtenir plus d’alias
 banner-pack-upgrade-copy = Avec des alias de messagerie illimités et votre propre domaine de messagerie, { -brand-name-firefox } { -brand-name-relay-premium } vous aide à rester protégé·e en ligne.
 banner-pack-upgrade-cta = Mettre à niveau maintenant
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Vous pouvez créer n’importe quelle adresse @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Vous pouvez créer n’importe quelle adresse @{ $subdomain }
+banner-choose-subdomain-description = Vous pouvez créer n’importe quelle adresse @{ $subdomain }
 
 ## Error Messages
 

--- a/ia/app.ftl
+++ b/ia/app.ftl
@@ -213,11 +213,9 @@ banner-choose-subdomain-submit = Obtener le dominio
 banner-pack-upgrade-headline-html = Promove a <strong> { -brand-name-relay-premium } de { -brand-name-firefox }</strong> pro obtener plus aliases
 banner-pack-upgrade-copy = Con aliases de e-mail illimitate e tu proprie dominio e-mail, { -brand-name-relay-premium } de { -brand-name-firefox } te adjuta a restar protegite online.
 banner-pack-upgrade-cta = Promover ora
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Tu pote crear ulle adresse @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Tu pote crear ulle adresse @{ $subdomain }
+banner-choose-subdomain-description = Tu pote crear ulle adresse @{ $subdomain }
 
 ## Success Messages
 

--- a/it/app.ftl
+++ b/it/app.ftl
@@ -219,11 +219,9 @@ banner-choose-subdomain-submit = Ottieni dominio
 banner-pack-upgrade-headline-html = Aggiorna a <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> per ottenere più alias
 banner-pack-upgrade-copy = Con alias illimitati e il tuo dominio email personale, { -brand-name-firefox } { -brand-name-relay-premium } ti aiuta a rimanere protetto online.
 banner-pack-upgrade-cta = Aggiorna adesso
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Puoi creare qualsiasi indirizzo @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Puoi creare qualsiasi indirizzo @{ $subdomain }
+banner-choose-subdomain-description = Puoi creare qualsiasi indirizzo @{ $subdomain }
 
 ## Success Messages
 

--- a/nl/app.ftl
+++ b/nl/app.ftl
@@ -215,11 +215,9 @@ banner-choose-subdomain-submit = Domein verkrijgen
 banner-pack-upgrade-headline-html = Upgrade naar <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> om meer aliassen te verkrijgen
 banner-pack-upgrade-copy = Met onbeperkte e-mailaliassen en uw eigen e-maildomein, helpt { -brand-name-firefox } { -brand-name-relay-premium } u online beschermd te blijven.
 banner-pack-upgrade-cta = Nu upgraden
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = U kunt elk adres @{ $subdomain } verzinnen
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = U kunt elk adres @{ $subdomain } verzinnen
+banner-choose-subdomain-description = U kunt elk adres @{ $subdomain } verzinnen
 
 ## Success Messages
 

--- a/pt-BR/app.ftl
+++ b/pt-BR/app.ftl
@@ -215,11 +215,9 @@ banner-choose-subdomain-submit = Obter domínio
 banner-pack-upgrade-headline-html = Mude para o <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> para ter mais endereços de redirecionamento
 banner-pack-upgrade-copy = Com endereços de redirecionamento de email ilimitados e seu próprio domínio de email, o { -brand-name-firefox } { -brand-name-relay-premium } ajuda você a se manter protegido online.
 banner-pack-upgrade-cta = Mude agora para a versão premium
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Você pode criar qualquer endereço @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Você pode criar qualquer endereço @{ $subdomain }
+banner-choose-subdomain-description = Você pode criar qualquer endereço @{ $subdomain }
 
 ## Success Messages
 

--- a/sv-SE/app.ftl
+++ b/sv-SE/app.ftl
@@ -214,11 +214,9 @@ banner-choose-subdomain-submit = Skaffa en domän
 banner-pack-upgrade-headline-html = Uppgradera till <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> för att få fler alias
 banner-pack-upgrade-copy = Med obegränsade e-postalias och din egen e-postdomän hjälper { -brand-name-firefox } { -brand-name-relay-premium } dig att hålla dig skyddad online.
 banner-pack-upgrade-cta = Uppgradera nu
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Du kan skapa vilken adress som helst @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Du kan skapa vilken adress som helst @{ $subdomain }
+banner-choose-subdomain-description = Du kan skapa vilken adress som helst @{ $subdomain }
 
 ## Error Messages
 

--- a/uk/app.ftl
+++ b/uk/app.ftl
@@ -215,11 +215,9 @@ banner-choose-subdomain-submit = Отримати домен
 banner-pack-upgrade-headline-html = Оновіться до <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong>, щоб отримати більше псевдоадрес
 banner-pack-upgrade-copy = Завдяки необмеженій кількості псевдоадрес е-пошти та вашому власному домену електронної пошти, { -brand-name-firefox } { -brand-name-relay-premium } допомагає вам захистити себе в інтернеті.
 banner-pack-upgrade-cta = Оновити зараз
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = Ви можете створити будь-яку адресу @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = Ви можете створити будь-яку адресу @{ $subdomain }
+banner-choose-subdomain-description = Ви можете створити будь-яку адресу @{ $subdomain }
 
 ## Success Messages
 

--- a/zh-CN/app.ftl
+++ b/zh-CN/app.ftl
@@ -203,11 +203,9 @@ banner-choose-subdomain-submit = 注册子域名
 banner-pack-upgrade-headline-html = 升级为 <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> 即可获取更多马甲
 banner-pack-upgrade-copy = { -brand-name-firefox } { -brand-name-relay-premium } 的无限量马甲邮箱 + 个人邮箱子域名，助力您的在线安全。
 banner-pack-upgrade-cta = 立即升级
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = 您可以使用任意前缀 @{ $subdomain }
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = 您可以使用任意前缀 @{ $subdomain }
+banner-choose-subdomain-description = 您可以使用任意前缀 @{ $subdomain }
 
 ## Success Messages
 

--- a/zh-TW/app.ftl
+++ b/zh-TW/app.ftl
@@ -203,11 +203,9 @@ banner-choose-subdomain-submit = 註冊網域
 banner-pack-upgrade-headline-html = 升級到 <strong>{ -brand-name-firefox } { -brand-name-relay-premium }</strong> 即可產生更多別名
 banner-pack-upgrade-copy = { -brand-name-firefox } { -brand-name-relay-premium } 可透過無限量別名信箱與您個人的郵件網域功能，幫助讓您的上網更受保護。
 banner-pack-upgrade-cta = 立刻升級
-# This string is followed by name (string) that the user chooses
-banner-choose-subdomain-label = 您可使用任何 @{ $subdomain } 的信箱帳號
 # Variables:
 # $subdomain (url) - User-set subdomain
-banner-choose-subdomain-label = 您可使用任何 @{ $subdomain } 的信箱帳號
+banner-choose-subdomain-description = 您可使用任何 @{ $subdomain } 的信箱帳號
 
 ## Success Messages
 


### PR DESCRIPTION
The ID `banner-choose-subdomain-label` was used twice. I've renamed
the second instance, and removed translations of the first instance
that were translated with the text of the second instance.