### PR TITLE
Fix link in comment

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -164,7 +164,7 @@ faq-question-7-answer = We now support attachment forwarding. However, there is 
 faq-question-8-question = What data does { -brand-name-firefox-relay } collect?
 
 # Variables:
-#   $url (url) - https://github.com/mozilla/fx-private-relay/issues/99
+#   $url (url) - https://www.mozilla.org/privacy/firefox-relay/
 #   $attrs (string) - specific attributes added to external links
 faq-question-8-answer-html = You can learn more about the data { -brand-name-firefox-relay } collects by taking a look at our <a href="{ $url }" { $attrs }>Privacy Notice</a>. You’re also able to optionally share data about the labels and site you use for your email aliases so we can provide you that service and improve it for you. 
 


### PR DESCRIPTION
Looks like either a faulty merge resolution or faulty copy-paste resulted in the URL from line 154 getting copied to line 167 instead of the intended URL as mentioned in #24. Thanks to @flodolo for [the heads-up](https://github.com/mozilla/fx-private-relay/issues/99#issuecomment-945382924).