### PR TITLE
restore faq-question-4-answer-html

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -242,6 +242,8 @@ faq-question-availability-answer = Free { -brand-name-relay } is available in mo
 
 faq-question-4-question = Can I reply to messages using my { -brand-name-relay } alias?
 faq-question-4-answer = { -brand-name-relay-premium } users can reply to a forwarded email within 3 months of receiving the email. Any CC’ed or BCC’ed addresses will not be included in your replies.
+faq-question-4-answer-html = { -brand-name-relay } does not yet offer the ability to reply using an alias.
+    If you try, nothing will happen. We are planning an additional feature to let you <a href="{ $url }" { $attrs }>reply anonymously to senders</a>.
 
 faq-question-browser-support-question = Can I use { -brand-name-relay } on other browsers or my mobile device?
 faq-question-browser-support-answer = Yes, you can generate { -brand-name-relay } aliases on other browsers or mobile devices simply by logging in to your { -brand-name-relay } dashboard.

--- a/zh-CN/app.ftl
+++ b/zh-CN/app.ftl
@@ -179,6 +179,7 @@ faq-question-1-answer-a = 虽然 { -brand-name-relay } 本身不会过滤垃圾�
 #   $attrs (string) - specific attributes added to external links
 faq-question-1-answer-b-html = 若您发现来自所有马甲的垃圾邮件存在更广泛的问题，请<a href="{ $url }" { $attrs }>向我们报告</a>，以便我们考虑为此调整 SES 垃圾邮件判别标准。若您将这些报告为垃圾邮件，您的邮件服务商会将 { -brand-name-relay } 视为垃圾邮件的来源，而非原始发件人。
 faq-question-4-question = 我可以用我的 { -brand-name-relay } 马甲回邮件吗？
+faq-question-4-answer-html = { -brand-name-relay } 暂不支持使用马甲邮箱回复邮件。若您要尝试，将会耽误您人生几分钟。不过，我们正计划推出新功能，让您可以<a href="{ $url }" { $attrs }>匿名回复邮件</a>。
 faq-question-8-question = { -brand-name-firefox-relay } 会收集哪些数据？
 # Variables:
 #   $url (url) - https://www.mozilla.org/privacy/firefox-relay/

--- a/zh-TW/app.ftl
+++ b/zh-TW/app.ftl
@@ -185,6 +185,7 @@ faq-question-1-answer-a = { -brand-name-relay } 本身不會過濾垃圾信，�
 #   $attrs (string) - specific attributes added to external links
 faq-question-1-answer-b-html = 若您發現更嚴重的問題，例如您的所有別名都開始轉發不想收到的郵件，請<a href="{ $url }" { $attrs }>回報給我們</a>這樣我們就可以考慮調整 SES 的垃圾信判讀門檻。若您將這些郵件回報為垃圾信，您的郵件服務業者會將整個 { -brand-name-relay } 當成垃圾信的來源，而非原始寄件者。
 faq-question-4-question = 我可以用我的 { -brand-name-relay } 別名回信嗎？
+faq-question-4-answer-html = { -brand-name-relay } 不提供使用別名信箱回信的功能。若您試著這樣作，將不會發生任何事。我們正計畫推出新功能，讓您可以<a href="{ $url }" { $attrs }>匿名地回信</a>。
 faq-question-8-question = { -brand-name-firefox-relay } 會收集哪些資料？
 # Variables:
 #   $url (url) - https://www.mozilla.org/privacy/firefox-relay/


### PR DESCRIPTION
relay.firefox.com/faq is showing:
<img width="536" alt="image" src="https://user-images.githubusercontent.com/71928/138158988-d76c043e-95fd-4336-a926-f5c1e545c3e1.png">

Because https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/30/files removed the `faq-question-4-answer-html` message in favor of the new `faq-question-4-answer` message. But, the site code is still looking for `faq-question-4-answer-html` until we make the full premium release update next week.

This restores the `faq-question-4-answer-html` message so the site code can find it again.