### PR TITLE
Add a missing period.

### DIFF
--- a/de/app.ftl
+++ b/de/app.ftl
@@ -234,7 +234,7 @@ faq-question-2-answer-html =
 #   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
 #   $attrs (string) - specific attributes added to external links
 faq-question-2-answer-v2-html =
-    Einige Websites akzeptieren möglicherweise keine E-Mail-Adresse, die eine Subdomain enthält (d. h. den „Relay“-Teil von @relay.firefox.com) und andere akzeptieren keine Adressen außer denen von Gmail-, Hotmail- oder Yahoo-Konten
+    Einige Websites akzeptieren möglicherweise keine E-Mail-Adresse, die eine Subdomain enthält (d. h. den „Relay“-Teil von @relay.firefox.com) und andere akzeptieren keine Adressen außer denen von Gmail-, Hotmail- oder Yahoo-Konten.
     Wenn Sie keine Alias-E-Mail-Adresse von { -brand-name-relay } verwenden können, <a href="{ $url }" { $attrs }>teilen Sie uns dies bitte mit</a>.
 faq-question-1-question = Was ist mit Spam?
 faq-question-1-answer-a = { -brand-name-relay } filtert keinen Spam, aber unser E-Mail-Partner Amazon SES blockiert Spam und Schadsoftware. Wenn { -brand-name-relay } unerwünschte Nachrichten weiterleitet, können Sie Ihre { -brand-name-relay }-Einstellungen ändern, um Nachrichten zu blockieren, die von der Alias-Adresse weitergeleitet werden.

--- a/en-GB/app.ftl
+++ b/en-GB/app.ftl
@@ -234,7 +234,7 @@ faq-question-2-answer-html =
 #   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
 #   $attrs (string) - specific attributes added to external links
 faq-question-2-answer-v2-html =
-    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts
+    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts.
     If you are not able to use a { -brand-name-relay } alias, <a href="{ $url }" { $attrs }>please let us know</a>.
 faq-question-1-question = What about spam?
 faq-question-1-answer-a = While { -brand-name-relay } does not filter for spam, our email partner Amazon SES does block spam and malware. If { -brand-name-relay } forwards messages you don’t want, you can update your { -brand-name-relay } settings to block messages from the alias forwarding them.

--- a/en/app.ftl
+++ b/en/app.ftl
@@ -227,7 +227,7 @@ faq-question-2-answer-html =
 #   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
 #   $attrs (string) - specific attributes added to external links
 faq-question-2-answer-v2-html =
-    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts
+    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts.
     If you are not able to use a { -brand-name-relay } alias, <a href="{ $url }" { $attrs }>please let us know</a>.
 
 faq-question-1-question = What about spam?


### PR DESCRIPTION
Hi @peiying2, as correctly pointed out by @flodolo [here](https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/30/files#r734927580), this string was missing a period :( Looking at the translations so far, all of them except the German and British English ones still included a period just like in v1 of the string, so apart from those no existing translations will need to be updated (and I speak both well enough to be able to confidently add the period myself). However, I'm wondering if Pontoon will show the updated string for translators translating this key in the future?

If not, what do you think the best way to deal with this would be?