### PR TITLE
Remove deprecated strings

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -220,27 +220,10 @@ faq-question-missing-emails-answer-b-html = If you’re a { -brand-name-relay-pr
 faq-question-missing-emails-answer-support-site-html = If you’re struggling with any of these issues, please <a href="{ $url }" { $attrs }>visit our support site</a>.
 
 faq-question-use-cases-question = When should I use { -brand-name-relay } aliases?
-# Deprecated (replaced by -part1 and -part2): faq-question-use-cases-answer 
-faq-question-use-cases-answer = You can use { -brand-name-relay } aliases most places you’d use your regular email address. We recommend using them when signing up for marketing/informational emails where you may want to control whether or not you receive emails in the future. We don’t recommend using aliases when you need your identity verified or for very important emails. For example, you’d want to share your real email address with your bank, your doctor, your lawyer, etc.
 faq-question-use-cases-answer-part1 = You can use { -brand-name-relay } aliases most places you’d use your regular email address. We recommend using them when signing up for marketing/informational emails where you may want to control whether or not you receive emails in the future.
 faq-question-use-cases-answer-part2 = We don’t recommend using aliases when you need your identity verified or for very important emails or those where you must receive attachments. For example, you’d want to share your real email address with your bank, your doctor, and your lawyer, as well as when receiving concert or flight boarding passes.
 
 faq-question-2-question = Why won’t a site accept my { -brand-name-relay } alias?
-# Deprecated
-# Variables:
-#   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
-#   $attrs (string) - specific attributes added to external links
-faq-question-2-answer-html =
-    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts.
-    As { -brand-name-firefox-relay } grows in popularity and issues more aliases, our service might be placed on a blocklist. 
-    If you are not able to use a { -brand-name-relay } alias, <a href="{ $url }" { $attrs }>please let us know</a>.
-# Deprecated
-# Variables:
-#   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
-#   $attrs (string) - specific attributes added to external links
-faq-question-2-answer-v2-html =
-    Some sites may not accept an email address that includes a subdomain (i.e., the “relay” portion of @relay.firefox.com) and others have stopped accepting all addresses except those from Gmail, Hotmail or Yahoo accounts.
-    If you are not able to use a { -brand-name-relay } alias, <a href="{ $url }" { $attrs }>please let us know</a>.
 # Variables:
 #   $url (url) - https://addons.mozilla.org/firefox/addon/private-relay/
 #   $attrs (string) - specific attributes added to external links
@@ -259,16 +242,11 @@ faq-question-availability-question = Where is { -brand-name-relay } available?
 faq-question-availability-answer = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, France, Belgium, Austria, Spain, Italy, Switzerland, Netherlands, and Ireland.
 
 faq-question-4-question = Can I reply to messages using my { -brand-name-relay } alias?
-faq-question-4-answer = { -brand-name-relay-premium } users can reply to a forwarded email within 3 months of receiving the email. Any CC’ed or BCC’ed addresses will not be included in your replies.
-# Deprecated
-faq-question-4-answer-v2 = { -brand-name-relay-premium } users can reply to a forwarded email within 3 months of receiving the email. If you add a CC or BCC when you reply back to an email, your original email address will be exposed to the receivers and those on the email. If you do not want your original email address exposed, do not add CCs or BCCs when replying.
 faq-question-4-answer-v3 = { -brand-name-relay-premium } users can reply to a forwarded email within 3 months of receiving the email. If you add a CC or BCC when you reply back to an email, your original email address will be exposed to the recipient and those on the email. If you do not want your original email address exposed, do not add CCs or BCCs when replying.
 faq-question-4-answer-html = { -brand-name-relay } does not yet offer the ability to reply using an alias.
     If you try, nothing will happen. We are planning an additional feature to let you <a href="{ $url }" { $attrs }>reply anonymously to senders</a>.
 
 faq-question-subdomain-characters-question = What characters can I use to create a subdomain?
-# Deprecated
-faq-question-subdomain-characters-answer = Only lower case English alphabet, numbers, and dashes (-).
 faq-question-subdomain-characters-answer-v2 = You can only use lower-case English letters, numbers, and hyphens to create a subdomain.
 
 faq-question-browser-support-question = Can I use { -brand-name-relay } on other browsers or my mobile device?
@@ -281,8 +259,6 @@ faq-question-mozmail-question = Why did my aliases start to use the domain “mo
 faq-question-mozmail-answer = We made the switch from “relay.firefox.com” to “mozmail.com” in order to make it possible to get a custom email domain, such as alias@yourdomain.mozmail.com. Custom email domains, available to { -brand-name-relay-premium } subscribers, also make your email aliases much easier to remember than random aliases.
 
 faq-question-attachments-question = Will { -brand-name-firefox-relay } forward emails with attachments?
-# Deprecated
-faq-question-attachments-answer = Yes, { -brand-name-firefox-relay } supports forwarded emails with attachments of up to { email-size-limit } in size. If an email has an attachment larger than { email-size-limit }, it will not be forwarded.
 faq-question-attachments-answer-v2 = We now support attachment forwarding. However, there is a { email-size-limit } limit for email forwarding using { -brand-name-relay }. Any emails larger than { email-size-limit } will not be forwarded.
 
 faq-question-unsubscribe-domain-question = What happens to my custom domain if I unsubscribe from { -brand-name-relay-premium }?
@@ -296,23 +272,6 @@ faq-question-8-answer-html = You can learn more about the data { -brand-name-fir
 
 faq-question-email-storage-question = Does { -brand-name-relay } store my emails?
 faq-question-email-storage-answer = Under the rare circumstance in which the service is down, we may temporarily store your emails until we are able to send them. We will never store your emails for longer than three days.
-
-# Deprecated
-faq-question-3-question = Is { -brand-name-relay } available only in the US?
-# Deprecated
-faq-question-3-answer = The site is currently only available in English, but you can use the service anywhere.
-# Deprecated
-faq-question-5-question = Can I make up my own { -brand-name-relay } alias using the @relay.firefox.com domain?
-# Deprecated
-faq-question-5-answer = Not currently, but we are considering new features including letting you create your own alias with a designated domain.
-# Deprecated
-faq-question-6-question = What happens if { -brand-name-mozilla } shuts down the { -brand-name-firefox-relay } service?
-# Deprecated
-faq-question-6-answer = We will give you advance notice that you need to change the email address of any accounts that are using { -brand-name-relay } aliases.
-# Deprecated
-faq-question-7-question = What if an email sent to my alias contains an attachment?
-# Deprecated
-faq-question-7-answer = We now support attachment forwarding. However, there is a { email-size-limit } limit for email forwarding using { -brand-name-relay }. Any emails larger than { email-size-limit } will not be forwarded.
 
 ## Profile Page (Logged In)
 


### PR DESCRIPTION
This supercedes #31.

All of these strings are no longer in use and can thus be skipped by translators.