### PR TITLE
Add strings for free-user promo-blocking UI

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -502,6 +502,11 @@ profile-promo-email-blocking-label-promotionals = Block promotions
 profile-promo-email-blocking-label-none = Block all
 profile-promo-email-blocking-label-forwarding = { profile-label-forwarding }
 profile-promo-email-blocking-label-not-forwarding = Not forwarding
+profile-promo-email-blocking-option-promotionals-premiumonly-marker = ({ -brand-name-premium } only)
+profile-promo-email-blocking-description-promotionals-locked-label = Available to { -brand-name-relay-premium } subscribers
+profile-promo-email-blocking-description-promotionals-locked-cta = Upgrade now
+profile-promo-email-blocking-description-promotionals-locked-waitlist-cta = Join the { -brand-name-relay-premium } waitlist
+profile-promo-email-blocking-description-promotionals-locked-close = Close
 
 ## Banner Messages (displayed on the profile page)
 
@@ -632,6 +637,7 @@ popover-custom-alias-explainer-close-button-label = Close
 # Checkbox the user can click to adjust the block level of the new mask
 popover-custom-alias-explainer-promotional-block-checkbox = Block promotional emails
 popover-custom-alias-explainer-promotional-block-tooltip-2 = Enable Block Promotional Emails on a mask to stop marketing emails from reaching your inbox.
+popover-custom-alias-explainer-promotional-block-tooltip-trigger = More info
 
 ## Tip about using custom masks
 


### PR DESCRIPTION
Can be merged at the same time as #78 to minimise notifications for localisers. These are the strings for https://github.com/mozilla/fx-private-relay/pull/1673.

This can be tried out by clicking "Generate new mask" at https://deploy-preview-1673--fx-relay-demo.netlify.app/?mockId=empty, but it's essentially this UI:

![image](https://user-images.githubusercontent.com/4251/167132398-3e82485f-41f6-47a0-8506-b872ee3c9fca.png)
