### PR TITLE
Add strings for MPP-1709 Mobile Menu

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -62,6 +62,18 @@ nav-profile-contact = Contact us
 nav-profile-contact-tooltip = Get in touch about { -brand-name-relay-premium }
 nav-profile-image-alt = { -brand-name-firefox-account(capitalization: "uppercase") } Avatar
 
+# Mobile menu icons 
+
+menu-upgrade-button = Upgrade 
+menu-toggle-open = Open menu
+menu-toggle-close = Close menu
+nav-dashboard = Dashboard
+nav-settings = Settings
+nav-support = Help and Support 
+nav-sign-out = Sign Out 
+nav-avatar = User avatar
+nav-contact = Contact Us
+
 ## Footer
 
 nav-footer-privacy = Privacy


### PR DESCRIPTION
This adds strings for the mobile menu navigation. 

<img width="291" alt="image" src="https://user-images.githubusercontent.com/3924990/168228872-4c7a242d-2e5f-42fd-90f7-3ee5f804450f.png">
