### PR TITLE
Add missing "tips" string

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -641,6 +641,11 @@ tips-footer-link-feedback-label = Feedback
 tips-footer-link-feedback-tooltip = Give feedback
 tips-footer-link-support-label = Support
 tips-footer-link-support-tooltip = Contact support
+# Label for each of the dots representing a tip in a panel in the bottom right-hand corner.
+# Variables
+#   $nr (number) - Which tip can be seen by clicking/tapping this particular dot.
+tips-switcher-label = Tip { $nr }
+tips-toast-button-expand-label = Learn more
 
 ## Modal for generating a custom mask
 
@@ -775,13 +780,6 @@ modal-domain-register-success-2 = { $subdomain } is now your email subdomain!
 #   $domain (string) - Applicable domain, i.e. `.mozmail.com`
 modal-domain-register-success-3 = <subdomain>{ $subdomain }</subdomain><domain>.{ $domain }</domain> is now your email subdomain!
 modal-domain-register-success-copy-2 = Now you can create unlimited custom email masks!
-
-## The "Help & Tips" area at the bottom of the page
-
-# Label for each of the dots representing a tip in a panel in the bottom right-hand corner.
-# Variables
-#   $nr (number) - Which tip can be seen by clicking/tapping this particular dot.
-tips-switcher-label = Tip { $nr }
 
 ## Evergreen Survey (displayed on the profile page)
 


### PR DESCRIPTION
Also move `tips-toast-button-expand-label` to be grouped with the
other tips strings.