### PR TITLE
Additional string for API key copy feature

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -340,6 +340,7 @@ settings-button-save-tooltip = Apply your chosen settings.
 setting-label-api-key = API Key
 # This is a label that appears on hover to copy the API key
 settings-button-copy = Click to copy
+setting-api-key-copied = Copied!
 
 ## FAQ Page
 


### PR DESCRIPTION
Followup to #84.

This was originally going to re-use profile-label-copied, but since
this is a different context, and Pontoon suggesting strings to
re-use anyway, I added a new string.