### PR TITLE
Add strings for tracker blocking callouts

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -220,6 +220,7 @@ landing-pricing-body-2 = Try { -brand-name-firefox-relay } email masks and start
 landing-pricing-free-price = Free
 landing-pricing-free-feature-1-2 = Up to 5 email masks
 landing-pricing-free-feature-2 = Browser extension
+landing-pricing-free-feature-3 = Email tracker removal
 landing-pricing-free-description = Try { -brand-name-firefox-relay } masks and start protecting your email inbox.
 landing-pricing-free-cta = Get { -brand-name-relay }
 # This is shown on the overview of the free plan for people who in countries in which Premium is not yet available
@@ -237,6 +238,7 @@ landing-pricing-premium-feature-3-2 = Your own email subdomain
 landing-pricing-premium-feature-3-subheader = youremail@yourdomain.mozmail.com
 landing-pricing-premium-feature-4 = Reply to forwarded emails
 landing-pricing-premium-feature-5 = Block promotional emails
+landing-pricing-premium-feature-6 = Email tracker removal
 
 landing-pricing-waitlist-description = { -brand-name-firefox-relay-premium } is not currently available in your country. Please share your email to be notified as soon as it is.
 landing-pricing-waitlist-cta = Join Waitlist
@@ -321,12 +323,17 @@ premium-promo-perks-headline = Why upgrade to { -brand-name-firefox-relay-premiu
 premium-promo-perks-lead-2 = With { -brand-name-firefox-relay-premium }, you get all the inbox protection and management of { -brand-name-relay }, but with unlimited email masks and your own custom subdomain to make managing your inbox even easier.
 premium-promo-perks-cta-label = Upgrade now
 premium-promo-perks-cta-tooltip = Upgrade to { -brand-name-firefox-relay-premium }
+premium-promo-perks-pill-new = New!
 premium-promo-perks-perk-unlimited-headline-2 = Create unlimited email masks
 premium-promo-perks-perk-unlimited-body-2 = No more five-mask limit: with { -brand-name-relay-premium }, you can generate as many masks as you need to help protect your email inbox from spammers and online trackers. You can even reply to emails without exposing your true address.
 premium-promo-perks-perk-custom-domain-headline-2 = Choose your own custom subdomain
 premium-promo-perks-perk-custom-domain-body-2 = With a custom subdomain, you can create masks that are easier than ever to remember and share. Need one for restaurant reservations? Use one like food@mydomain.mozmail.com — No need to create the mask beforehand.
 premium-promo-perks-perk-dashboard-headline-2 = Control your masks from the dashboard
 premium-promo-perks-perk-dashboard-body-2 = Manage all your email masks in the easy-to-use dashboard: if you find that one receives unwanted messages, you can block those messages from reaching your inbox.
+premium-promo-perks-perk-block-promotionals-headline = Block promotional emails
+premium-promo-perks-perk-block-promotionals-body = With { -brand-name-relay-premium }, you can block promotional emails from reaching your inbox while still receiving emails like receipts or shipping information.
+premium-promo-perks-perk-tracker-blocking-headline = Remove email trackers
+premium-promo-perks-perk-tracker-blocking-body = Now { -brand-name-relay } can help you stop email tracking — your email masks will remove common email trackers from any emails forwarded to you, helping you stay invisible to trackers and advertisers.
 
 premium-promo-use-cases-headline-2 = Use { -brand-name-relay } email masks anywhere
 premium-promo-use-cases-shopping-heading = Shopping


### PR DESCRIPTION
These are for new callouts on the landing page and the Premium
interstitial to promote tracker removal and promotional email
blocking.

![image](https://user-images.githubusercontent.com/4251/181562589-7207ec14-69d7-4d8c-b125-5a15d4c949ea.png)

and

![image](https://user-images.githubusercontent.com/4251/181562732-5280cc93-dfc4-4b85-b392-bbd9a84eb991.png)
