### PR TITLE
Enable localisation to pt-PT

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -21,6 +21,7 @@ locales = [
   "ja",
   "nl",
   "pt-BR",
+  "pt-PT",
   "ru",
   "sk",
   "skr",


### PR DESCRIPTION
@peiying2 Do we also need to create empty `/pt-PT/app.ftl` and `pt-PT/brands.ftl` files, or will Pontoon do so automatically? (I'm assuming the latter, since we didn't have to do that for the new files for `en-MX` and `fr` either.)

Fixes https://github.com/mozilla/fx-private-relay/issues/2698.