### PR TITLE
Add new navigation labels

### DIFF
--- a/en/app.ftl
+++ b/en/app.ftl
@@ -16,6 +16,8 @@ logo-alt= { -brand-name-firefox-relay }
 logo-premium-alt= { -brand-name-firefox-relay-premium }
 nav-menu = Menu
 nav-home = Home
+nav-email-dashboard = Email Masks
+nav-phone-dashboard = Phone Masks
 label-open-menu = Open menu
 avatar-tooltip = Profile
 
@@ -36,6 +38,7 @@ nav-profile-contact = Contact us
 # This is only visible to Premium users.
 nav-profile-contact-tooltip = Get in touch about { -brand-name-relay-premium }
 nav-profile-image-alt = { -brand-name-firefox-account(capitalization: "uppercase") } Avatar
+# Deprecated
 nav-phone = Phone Number
 nav-duo-description = Switch dashboards
 nav-duo-email-mask-alt = Email masks
@@ -46,6 +49,7 @@ nav-duo-phone-mask-alt = Phone masks
 menu-upgrade-button = Upgrade
 menu-toggle-open = Open menu
 menu-toggle-close = Close menu
+# Deprecated
 nav-dashboard = Dashboard
 nav-settings = Settings
 nav-support = Help and Support


### PR DESCRIPTION
It's now 

![image](https://user-images.githubusercontent.com/4251/203380838-b4e70567-9639-4e5e-9892-ea570615636c.png)

and

![image](https://user-images.githubusercontent.com/4251/203380889-94933464-a526-4daf-9da3-d425b2125e8b.png)

instead of

![image](https://user-images.githubusercontent.com/4251/203380942-99358458-3f17-4657-95a7-1916b8364e36.png)

and

![image](https://user-images.githubusercontent.com/4251/203380983-5b5f7f98-906a-4372-bf73-8df7c5f300d1.png)
