### PR TITLE
Fix "activity" misspelling

### DIFF
--- a/en/bundle.ftl
+++ b/en/bundle.ftl
@@ -6,7 +6,7 @@ vpn-relay-welcome-headline = Welcome to your new protection plan
 vpn-relay-welcome-subheadline = { -brand-name-firefox-relay } + { -brand-name-mozilla-vpn }
 vpn-relay-go-relay-body = Protect your email inbox and your phone number
 vpn-relay-go-relay-cta = Go to { -brand-name-relay }
-vpn-relay-go-vpn-body = Protect your connection and online actvitiy
+vpn-relay-go-vpn-body = Protect your connection and online activity
 vpn-relay-go-vpn-cta = Download { -brand-name-mozilla-vpn }
 
 ## VPN and Relay Bundle What's New Announcement


### PR DESCRIPTION
I don't think we need a new string for this, since the error is only in the English version - I saw that the Spanish and French translations translated it properly :)