### PR TITLE
MPP-2635: Add SMS error strings

### DIFF
--- a/en/phones.ftl
+++ b/en/phones.ftl
@@ -233,7 +233,7 @@ tips-multi-replies-content = Just start your message with the last 4 digits of t
 sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
 # Variables
 #   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
-sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
+sms-error-no-phone-log = The reply feature requires { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can reply to future messages by enabling “Caller and texts log” in Settings: { $account_settings_url }
 
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number

--- a/en/phones.ftl
+++ b/en/phones.ftl
@@ -227,3 +227,27 @@ phone-masking-splash-blocking-example-date = Today
 
 tips-multi-replies-heading = Reply to any text with your phone mask
 tips-multi-replies-content = Just start your message with the last 4 digits of that sender’s number.
+
+## SMS reply error messages
+
+sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
+# Variables
+#   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
+sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
+
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+sms-error-short-prefix-matches-no-senders = Message failed to send. There is no phone number in this thread ending in { $short_prefix }. Please check the number and try again.
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the phone number ending in { $short_prefix }.
+
+# Variables
+#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
+sms-error-full-number-matches-no-senders = Message failed to send. There is no previous sender with the phone number { $full_number }. Please check the number and try again.
+# Variables
+#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
+sms-error-no-body-after-full-number = Message failed to send. Please include a message after the phone number { $full_number }.


### PR DESCRIPTION
Phone users who fail to reply to an SMS message get one of these error messages. They were copy-edited in [MPPUX-771](https://mozilla-hub.atlassian.net/browse/MPPUX-771).