### PR TITLE
Deletion of domain tooltip strings, addition of new modal design strings

### DIFF
--- a/en/misc.ftl
+++ b/en/misc.ftl
@@ -52,6 +52,13 @@ tips-footer-link-support-tooltip = Contact support
 tips-switcher-label = Tip { $nr }
 tips-toast-button-expand-label = Learn more
 
+## Popover explaining how custom masks work
+
+popover-custom-alias-explainer-heading-2 = How to create custom masks
+popover-custom-alias-explainer-explanation-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.
+popover-custom-alias-explainer-generate-button-heading-2 = Generate a custom mask manually
+popover-custom-alias-explainer-generate-button-label-2 = Generate custom mask
+popover-custom-alias-explainer-close-button-label = Close
 # Checkbox the user can click to adjust the block level of the new mask
 popover-custom-alias-explainer-promotional-block-checkbox = Block promotional emails
 popover-custom-alias-explainer-promotional-block-tooltip-2 = Enable Block Promotional Emails on a mask to stop marketing emails from reaching your inbox.

--- a/en/misc.ftl
+++ b/en/misc.ftl
@@ -52,13 +52,6 @@ tips-footer-link-support-tooltip = Contact support
 tips-switcher-label = Tip { $nr }
 tips-toast-button-expand-label = Learn more
 
-## Popover explaining how custom masks work
-
-popover-custom-alias-explainer-heading-2 = How to create custom masks
-popover-custom-alias-explainer-explanation-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.
-popover-custom-alias-explainer-generate-button-heading-2 = Generate a custom mask manually
-popover-custom-alias-explainer-generate-button-label-2 = Generate custom mask
-popover-custom-alias-explainer-close-button-label = Close
 # Checkbox the user can click to adjust the block level of the new mask
 popover-custom-alias-explainer-promotional-block-checkbox = Block promotional emails
 popover-custom-alias-explainer-promotional-block-tooltip-2 = Enable Block Promotional Emails on a mask to stop marketing emails from reaching your inbox.

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -5,12 +5,13 @@
 ## Modal for generating a custom mask
 
 modal-custom-alias-picker-heading-2 = Create a new custom mask
-modal-custom-alias-picker-warning-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customsubdomain.mozmail.com” next time you shop online, for example.
-modal-custom-alias-picker-form-heading-2 = Or, create a custom mask manually
-modal-custom-alias-picker-form-prefix-label-2 = Enter email mask prefix
+modal-custom-alias-picker-form-prefix-label-2 = Enter the text that goes before the @ symbol:
+modal-custom-alias-picker-form-prefix-placeholder = @customdomain.mozmail.com 
+modal-custom-alias-picker-tip-2 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
+
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).
-modal-custom-alias-picker-form-prefix-placeholder = e.g. “coffee”
+
 modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
 modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
 modal-custom-alias-picker-form-prefix-invalid-warning-2 = Email masks can only contain lowercase letters, numbers, periods, and hyphens, and may not start or end with a period or hyphen.

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -4,13 +4,15 @@
 
 ## Modal for generating a custom mask
 
+modal-custom-alias-picker-tip = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
+
 modal-custom-alias-picker-heading-2 = Create a new custom mask
 modal-custom-alias-picker-warning-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customsubdomain.mozmail.com” next time you shop online, for example.
 modal-custom-alias-picker-form-heading-2 = Or, create a custom mask manually
-modal-custom-alias-picker-form-prefix-label-2 = Enter email mask prefix
+modal-custom-alias-picker-form-prefix-label-v3 = Enter the text that goes before the @ symbol:
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).
-modal-custom-alias-picker-form-prefix-placeholder = e.g. “coffee”
+modal-custom-alias-picker-form-prefix-placeholder-v2 = @customdomain.mozmail.com 
 modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
 modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
 modal-custom-alias-picker-form-prefix-invalid-warning-2 = Email masks can only contain lowercase letters, numbers, periods, and hyphens, and may not start or end with a period or hyphen.

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -4,7 +4,7 @@
 
 ## Modal for generating a custom mask
 
-modal-custom-alias-picker-tip = Tip: To create a custom mask anytime, make it up on the spot. If you use your { -brand-name-firefox-relay } domain, it’ll work, even if you didn’t generate it here first.
+modal-custom-alias-picker-tip = Tip: To create a custom mask anytime, make it up on the spot. If you use your { -brand-name-relay } domain, it’ll work, even if you didn’t generate it here first.
 
 modal-custom-alias-picker-heading-2 = Create a new custom mask
 modal-custom-alias-picker-warning-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customsubdomain.mozmail.com” next time you shop online, for example.

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -5,13 +5,12 @@
 ## Modal for generating a custom mask
 
 modal-custom-alias-picker-heading-2 = Create a new custom mask
-modal-custom-alias-picker-form-prefix-label-2 = Enter the text that goes before the @ symbol:
-modal-custom-alias-picker-form-prefix-placeholder = @customdomain.mozmail.com 
-modal-custom-alias-picker-tip-2 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
-
+modal-custom-alias-picker-warning-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customsubdomain.mozmail.com” next time you shop online, for example.
+modal-custom-alias-picker-form-heading-2 = Or, create a custom mask manually
+modal-custom-alias-picker-form-prefix-label-2 = Enter email mask prefix
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).
-
+modal-custom-alias-picker-form-prefix-placeholder = e.g. “coffee”
 modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
 modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
 modal-custom-alias-picker-form-prefix-invalid-warning-2 = Email masks can only contain lowercase letters, numbers, periods, and hyphens, and may not start or end with a period or hyphen.

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -4,10 +4,10 @@
 
 ## Modal for generating a custom mask
 
-modal-custom-alias-picker-heading-2 = Create a new custom mask
-modal-custom-alias-picker-form-prefix-label-2 = Enter the text that goes before the @ symbol:
+modal-custom-alias-picker-heading-v3 = Create a new custom mask
+modal-custom-alias-picker-form-prefix-label-v3 = Enter the text that goes before the @ symbol:
 modal-custom-alias-picker-form-prefix-placeholder = @customdomain.mozmail.com 
-modal-custom-alias-picker-tip-2 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
+modal-custom-alias-picker-tip-v3 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
 
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -4,10 +4,10 @@
 
 ## Modal for generating a custom mask
 
-modal-custom-alias-picker-heading-v3 = Create a new custom mask
-modal-custom-alias-picker-form-prefix-label-v3 = Enter the text that goes before the @ symbol:
+modal-custom-alias-picker-heading-2 = Create a new custom mask
+modal-custom-alias-picker-form-prefix-label-2 = Enter the text that goes before the @ symbol:
 modal-custom-alias-picker-form-prefix-placeholder = @customdomain.mozmail.com 
-modal-custom-alias-picker-tip-v3 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
+modal-custom-alias-picker-tip-2 = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
 
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).

--- a/en/modals.ftl
+++ b/en/modals.ftl
@@ -4,15 +4,15 @@
 
 ## Modal for generating a custom mask
 
-modal-custom-alias-picker-tip = Tip: To create a custom mask anytime, make it up on the spot. If you use your Relay domain, it’ll work, even if you didn’t generate it here first.
+modal-custom-alias-picker-tip = Tip: To create a custom mask anytime, make it up on the spot. If you use your { -brand-name-firefox-relay } domain, it’ll work, even if you didn’t generate it here first.
 
 modal-custom-alias-picker-heading-2 = Create a new custom mask
 modal-custom-alias-picker-warning-2 = All you need to do is make up and share a unique mask that uses your custom subdomain — the mask will be generated automatically. Try “shop@customsubdomain.mozmail.com” next time you shop online, for example.
 modal-custom-alias-picker-form-heading-2 = Or, create a custom mask manually
-modal-custom-alias-picker-form-prefix-label-v3 = Enter the text that goes before the @ symbol:
+modal-custom-alias-picker-form-prefix-label-3 = Enter the text that goes before the @ symbol:
 # This is shown in placeholder of the form field in which users can pick a custom mask prefix for their own subdomain,
 # as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).
-modal-custom-alias-picker-form-prefix-placeholder-v2 = @customdomain.mozmail.com 
+modal-custom-alias-picker-form-prefix-placeholder-2 = @customdomain.mozmail.com 
 modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
 modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
 modal-custom-alias-picker-form-prefix-invalid-warning-2 = Email masks can only contain lowercase letters, numbers, periods, and hyphens, and may not start or end with a period or hyphen.


### PR DESCRIPTION
MPP-3239 - This task required removal of a tool-tip that appears when clicking your relay domain name. I deleted the strings corresponding to this tool-tip in misc.ftl 

MPP-3261 - Updated the strings in modals.ftl to match the new design for generating a mask.