### PR TITLE
Remove landing.ftl and faq.ftl from l10n.toml

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -45,12 +45,6 @@ locales = [
         "fr",
     ]
 [[paths]]
-    reference = "en/faq.ftl"
-    l10n = "{locale}/faq.ftl"
-[[paths]]
-    reference = "en/landing.ftl"
-    l10n = "{locale}/landing.ftl"
-[[paths]]
     reference = "en/layout.ftl"
     l10n = "{locale}/layout.ftl"
 [[paths]]


### PR DESCRIPTION
Part of migration of landing pages to bedrock. Removes landing.ftl and faq.ftl from paths to hide files in Pontoon.