### PR TITLE
MPP-3243 Rebrand Firefox Account in Firefox Relay

### DIFF
--- a/en/brands.ftl
+++ b/en/brands.ftl
@@ -20,10 +20,16 @@
 -brand-name-firefox-lockwise = Firefox Lockwise
 -brand-name-firefox-monitor = Firefox Monitor
 -brand-name-pocket = Pocket
+# Deprecated
 -brand-name-firefox-account =
     { $capitalization ->
        *[lowercase] Firefox account
         [uppercase] Firefox Account
     }
+-brand-name-mozilla-account =
+    { $capitalization ->
+       *[lowercase] Mozilla account
+        [uppercase] Mozilla Account
+    }     
 -brand-name-chrome = Chrome
 -brand-name-google-chrome = Google Chrome

--- a/en/faq.ftl
+++ b/en/faq.ftl
@@ -92,7 +92,9 @@ faq-question-acceptable-use-question = What are the acceptable uses of { -brand-
 #   $url (url) - link to Mozilla's Acceptable Use Policy, i.e. https://www.mozilla.org/about/legal/acceptable-use/
 #   $attrs (string) - specific attributes added to external links
 faq-question-acceptable-use-answer-a-html = { -brand-name-firefox-relay } has the same <a href="{ $url }" { $attrs }>conditions of use as all { -brand-name-mozilla } products</a>. We have a zero-tolerance policy when it comes to using { -brand-name-relay } for malicious purposes like spam, resulting in the termination of a user’s account. We take measures to prevent users from violating our conditions by:
+# Deprecated
 faq-question-acceptable-use-answer-measure-account = Requiring a { -brand-name-firefox-account(capitalization: "uppercase") } with a verified email address
+faq-question-acceptable-use-answer-measure-account-v2 = Requiring a { -brand-name-mozilla-account(capitalization: "uppercase") } with a verified email address
 faq-question-acceptable-use-answer-measure-unlimited-payment-2 = Requiring payment for a user to create more than five masks
 faq-question-acceptable-use-answer-measure-rate-limit-2 = Rate-limiting the number of masks that can be generated in one day
 #   $url (url) - link to the Terms of Service, i.e. https://www.mozilla.org/about/legal/terms/firefox-relay/

--- a/en/layout.ftl
+++ b/en/layout.ftl
@@ -25,7 +25,9 @@ avatar-tooltip = Profile
 nav-faq = FAQ
 nav-profile-sign-in = Sign In
 nav-profile-sign-up = Sign Up
+# Deprecated
 nav-profile-manage-fxa = Manage your { -brand-name-firefox-account(capitalization: "uppercase") }
+nav-profile-manage-fxa-v2 = Manage your { -brand-name-mozilla-account(capitalization: "uppercase") }
 nav-profile-sign-out = Sign Out
 nav-profile-sign-out-relay = Sign Out of { -brand-name-relay }
 nav-profile-sign-out-confirm = Are you sure you want to sign out?
@@ -37,7 +39,9 @@ nav-profile-help-tooltip = Get help using { -brand-name-relay }
 nav-profile-contact = Contact us
 # This is only visible to Premium users.
 nav-profile-contact-tooltip = Get in touch about { -brand-name-relay-premium }
+# Deprecated
 nav-profile-image-alt = { -brand-name-firefox-account(capitalization: "uppercase") } Avatar
+nav-profile-image-alt-v2 = { -brand-name-mozilla-account(capitalization: "uppercase") } Avatar
 nav-duo-description = Switch dashboards
 nav-duo-email-mask-alt = Email masks
 nav-duo-phone-mask-alt = Phone masks


### PR DESCRIPTION
string updates related to branding update - firefox account(s) to mozilla account(s)


```
nav-profile-manage-fxa-v2 = Manage your { -brand-name-mozilla-account(capitalization: "uppercase") }
nav-profile-image-alt-v2 = { -brand-name-mozilla-account(capitalization: "uppercase") } Avatar
faq-question-acceptable-use-answer-measure-account-v2 = Requiring a { -brand-name-mozilla-account(capitalization: "uppercase") } with a verified email address
-brand-name-mozilla-account =
    { $capitalization ->
       *[lowercase] Mozilla account
        [uppercase] Mozilla Account
    } 
```