### PR TITLE
New strings for API errors

### DIFF
--- a/en/misc.ftl
+++ b/en/misc.ftl
@@ -333,3 +333,8 @@ api-error-free-tier-no-subdomain-masks = Your free account does not include cust
 api-error-address-unavailable = “{ $unavailable_address }” could not be created. Please try again with a different mask name.
 api-error-need-subdomain = Please select a subdomain before creating a custom email address.
 api-error-account-is-paused = Your account is on pause.
+
+# Variables:
+#   $duplicate_address (string) - User-set email address that already exists
+api-error-duplicate-address = “{ $duplicate_address }” already exists. Please try again with a different mask name.
+api-error-address-not-editable = You cannot edit an existing domain address field.


### PR DESCRIPTION
Adds the strings from pending.ftl (https://github.com/mozilla/fx-private-relay/pull/4519/files#diff-8174cc17a6a13ddfac880bec453eac4d824ef69182ccf18c831ae52d3e3814a1R9-R10) into the locales repo